### PR TITLE
Bug with pushing new standup items

### DIFF
--- a/src/bot/SlackBot.ts
+++ b/src/bot/SlackBot.ts
@@ -271,7 +271,15 @@ export class SlackBot {
                         attendees: plNames,
                         content: parkingLotItems ? parkingLotItems : ""
                     }
+                } else {
+                    // push the new item onto the list
+                    d.parkingLotData!.push({
+                        userId: userId,
+                        attendees: plNames,
+                        content: parkingLotItems ? parkingLotItems : ""
+                    });
                 }
+
                 await this.dao.updateStandupParkingLotData(d);
             } else {
                 d = new StandupParkingLotData();


### PR DESCRIPTION
The parking lot was not story new standup items for that day. It could only update existing ones for the first user.