### PR TITLE
Bot validation

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,10 @@
-import {App, AwsLambdaReceiver, BlockAction, LogLevel, ModalView} from '@slack/bolt';
+import {App, AwsLambdaReceiver, BlockAction, LogLevel} from '@slack/bolt';
 import {AwsSecretsDataSource} from "./secrets/AwsSecretsDataSource";
 import {context, logger} from "./utils/context";
 import {APIGatewayProxyEvent} from "aws-lambda";
 import {SlackBot} from "./bot/SlackBot";
 import {DynamoDbStandupParkingLotDataDao} from "./data/DynamoDbStandupParkingLotDataDao";
-import {ChatScheduleMessageArguments, WebClient} from "@slack/web-api";
+import {ChatScheduleMessageArguments} from "@slack/web-api";
 import {ChatPostEphemeralArguments} from "@slack/web-api/dist/methods";
 import {formatDateToPrintable} from "./utils/datefunctions";
 
@@ -134,14 +134,10 @@ const init = async () => {
         } catch (error) {
             logger.error(error);
             let msg = (error as Error).message;
-            const viewArgs = slackBot.buildErrorView(msg);
+            const viewArgs = slackBot.buildErrorMessage(viewInput, msg);
             try {
                 logger.info(viewArgs);
-                await ack({
-                   response_action: "update",
-                   view: viewArgs
-                });
-
+                await client.chat.postEphemeral(viewArgs);
             } catch (e) {
                 logger.error("Secondary error", e);
             }

--- a/src/bot/BotViewBuilder.ts
+++ b/src/bot/BotViewBuilder.ts
@@ -491,4 +491,24 @@ export class BotViewBuilder {
         }
         return viewArgs;
     }
+
+    public buildErrorMessage(input: StandupInputData, msg: string): ChatPostEphemeralArguments {
+        const channelId = input.pm.channelId!;
+        const userId = input.pm.userId!;
+
+        return {
+            channel: channelId,
+            user: userId,
+            blocks: [
+                {
+                    type: "section",
+                    text: {
+                        type: "mrkdwn",
+                        text: msg
+                    }
+                }
+            ],
+            text: msg
+        };
+    }
 }

--- a/src/bot/BotViewBuilder.ts
+++ b/src/bot/BotViewBuilder.ts
@@ -2,7 +2,7 @@ import {ChatScheduleMessageArguments, ViewsOpenArguments} from "@slack/web-api";
 import {Block, ContextBlock, HeaderBlock, Logger, ModalView, SectionBlock} from "@slack/bolt";
 import {ChatPostEphemeralArguments} from "@slack/web-api/dist/methods";
 import {ChatMessageType, StandupInputData, UserInfo} from "./SlackBot";
-import {formatDateToMoment} from "../utils/datefunctions";
+import {formatDateToPrintable} from "../utils/datefunctions";
 
 export class ParkingLotDisplayItem {
     userName: string
@@ -237,7 +237,7 @@ export class BotViewBuilder {
      * @param args
      */
     public buildScheduledMessageDeleteMessage(msgId: string, channelId: string, postAt: number, userId: string, timezone: string, args: ChatScheduleMessageArguments): ChatPostEphemeralArguments {
-        const dateStr = formatDateToMoment(postAt, timezone);
+        const dateStr = formatDateToPrintable(postAt, timezone);
         const msg = "Your status below is scheduled to send on\n " + dateStr;
 
         const cmd = new DeleteCommand(msgId, channelId, postAt, userId);

--- a/src/bot/SlackBot.ts
+++ b/src/bot/SlackBot.ts
@@ -244,4 +244,19 @@ export class SlackBot {
         return this.viewBuilder.buildErrorView(msg);
     }
 
+    async validateBotUserInChannel(channelId: string, botId: string, client: WebClient): Promise<boolean> {
+        const channelData = await client.conversations.members({
+            channel: channelId,
+        });
+        // Get data about this bot to compare its usersID against the list
+        const botData = await client.bots.info({
+            bot: botId
+        })
+        const botUserId = botData.bot?.user_id;
+        return !!channelData.members?.find(m => {
+            return m === botUserId;
+        });
+
+    }
+
 }

--- a/src/bot/SlackBot.ts
+++ b/src/bot/SlackBot.ts
@@ -244,6 +244,10 @@ export class SlackBot {
         return this.viewBuilder.buildErrorView(msg);
     }
 
+    public buildErrorMessage(input: StandupInputData, msg: string): ChatPostEphemeralArguments {
+        return this.viewBuilder.buildErrorMessage(input, msg);
+    }
+
     async validateBotUserInChannel(channelId: string, botId: string, client: WebClient): Promise<boolean> {
         const channelData = await client.conversations.members({
             channel: channelId,

--- a/src/utils/datefunctions.ts
+++ b/src/utils/datefunctions.ts
@@ -1,6 +1,6 @@
 import moment from "moment-timezone";
 
-export function formatDateToMoment(dateTime: number, timezone: string): string {
+export function formatDateToPrintable(dateTime: number, timezone: string): string {
     const m = moment(dateTime).tz(timezone);
     return m.format("M/D/YYYY") + " at " + m.format("h:mm A");
 }


### PR DESCRIPTION
Validate that the bot is in channel upon view submission. This allows us to `ack()` quickly, rather than deferring until after `chat.postMessage` in order to be able to update the view. 