### PR TITLE
Warmup lambdas added for off-hours warming

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -90,6 +90,9 @@ functions:
   slack:
     provisionedConcurrency: 1
     concurrencyAutoscaling: ${self:custom.lambda.concurrencyAutoscaling}
+    warmup:
+      outOfOfficeHoursWarmer:
+        enabled: true
     handler: src/app.handler
     events:
       - http:
@@ -98,6 +101,9 @@ functions:
   worker:
     provisionedConcurrency: 1
     concurrencyAutoscaling: ${self:custom.lambda.concurrencyAutoscaling}
+    warmup:
+      outOfOfficeHoursWarmer:
+        enabled: true
     handler: src/worker.handler
     events:
       - http:
@@ -108,6 +114,7 @@ plugins:
   - serverless-offline
   - serverless-express
   - serverless-provisioned-concurrency-autoscaling
+  - serverless-plugin-warmup
 package:
   excludeDevDependencies: true
   individually: true
@@ -136,3 +143,14 @@ custom:
           action:
             maximum: 0
             minimum: 0
+  warmup:
+    outOfOfficeHoursWarmer:
+      enabled:
+        - prod
+      events:
+        # 4-11:59 UTC is 9pm - 4:59am MST
+        - schedule: cron(0/5 4-11 ? * MON-FRI *)
+        - schedule: cron(0/5 * ? * SAT-SUN *)
+      concurrency: 1
+      verbose: false
+      memorySize: 128

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import {AckFn, App, AwsLambdaReceiver, BlockAction, ButtonAction, LogLevel, ViewResponseAction} from '@slack/bolt';
+import {AckFn, App, AwsLambdaReceiver, LogLevel, ViewResponseAction} from '@slack/bolt';
 import {appContext, blockId, dataSource, logger} from "./utils/appContext";
 import {APIGatewayProxyEvent} from "aws-lambda";
 import {SlackBot} from "./bot/SlackBot";
@@ -7,9 +7,6 @@ import {DynamoDbStandupStatusDao} from "./data/DynamoDbStandupStatusDao";
 import {StandupViewData} from "./dto/StandupViewData";
 import {Timer} from "./utils/Timer";
 import {delegateToWorker, warmWorkerLambda} from "./utils/lambdautils";
-import {ACTION_NAMES} from "./bot/ViewConstants";
-import {ChangeMessageCommand} from "./bot/Commands";
-import {ChatPostEphemeralArguments} from "@slack/web-api/dist/methods";
 
 let app: App;
 

--- a/src/bot/BotViewBuilder.ts
+++ b/src/bot/BotViewBuilder.ts
@@ -39,7 +39,7 @@ export class BotViewBuilder {
      * `12345` YES
      * @private
      */
-    private storySearchRegex = new RegExp(/`((SC-)?(\d{5}))`/, "g");
+    private storySearchRegex = new RegExp(/`((SC-)?(\d{5}))`/, "gi");
 
     /**
      * Build the primary input view using block kit.
@@ -71,7 +71,7 @@ export class BotViewBuilder {
                         elements: [
                             {
                                 type: "mrkdwn",
-                                text: "Five-digit numbers surrounded by backticks `` and displayed as `code` will be linked to Shortcut stories.",
+                                text: "Five-digit numbers surrounded by backticks `` to display `code` can link to Shortcut stories. For example, `12345` or `SC-12345` or `sc-12345`",
                             },
                         ]
                     },

--- a/src/bot/SlackBot.ts
+++ b/src/bot/SlackBot.ts
@@ -76,6 +76,8 @@ export class SlackBot {
 
         const status = await this.statusDao.getStatusMessage(userId, messageId);
 
+        // Query the user so that we have the user's timezone
+        // TODO may not need this when we have saved the message's timezone offset
         const userInfo = await this.queryUser(userId, client);
 
         let blockData = await this.loadSavedStatusMessage(status, pm);
@@ -180,7 +182,7 @@ export class SlackBot {
             memberInfos = await this.queryUsers(viewInput.attendees, client);
         }
 
-        const blocks = this.viewBuilder.buildChatMessageOutputBlocks(messageType, userInfo, viewInput.yesterday, viewInput.today, viewInput.parkingLot, viewInput.pullRequests, memberInfos);
+        const blocks = this.viewBuilder.buildChatMessageOutputBlocks(messageType!, userInfo, viewInput.yesterday, viewInput.today, viewInput.parkingLot, viewInput.pullRequests, memberInfos);
 
         // post as the user who requested
         return {


### PR DESCRIPTION
This PR also slightly changes messaging for Shortcut story detection and formatting, looking for case-insensitive `SC-` now.

It probably makes sense to remove worker lambda since it adds overhead, and even though we can `ack()` responses quickly, we still need to operate on a `trigger_id` before 3 seconds.