### PR TITLE
Secrets issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,5 @@ dist
 .DS_Store
 
 volume
+
+.warmup

--- a/serverless.yml
+++ b/serverless.yml
@@ -91,7 +91,8 @@ functions:
     provisionedConcurrency: 1
     concurrencyAutoscaling: ${self:custom.lambda.concurrencyAutoscaling}
     warmup:
-      outOfOfficeHoursWarmer:
+#      outOfOfficeHoursWarmer:
+      default:
         enabled: true
     handler: src/app.handler
     events:
@@ -133,13 +134,18 @@ custom:
             maximum: 0
             minimum: 0
   warmup:
-    outOfOfficeHoursWarmer:
+    default:
+      events:
+        # warm up the lambda no matter what to make async init complete before signature can time out in 5 mins
+        # Another more complex solution would be AWS extension layers, but layers are not well-supported in serverless
+        - schedule: rate(4 minutes)
+#    outOfOfficeHoursWarmer:
       enabled:
         - prod
-      events:
+#      events:
         # 4-11:59 UTC is 9pm - 4:59am MST
-        - schedule: cron(0/5 4-11 ? * MON-FRI *)
-        - schedule: cron(0/5 * ? * SAT-SUN *)
+#        - schedule: cron(0/5 4-11 ? * MON-FRI *)
+#        - schedule: cron(0/5 * ? * SAT-SUN *)
       concurrency: 1
       verbose: false
       memorySize: 128

--- a/src/data/DynamoDbStandupStatusDao.ts
+++ b/src/data/DynamoDbStandupStatusDao.ts
@@ -2,6 +2,7 @@ import {StandupStatus, StatusMessage} from "./StandupStatus";
 import {StandupStatusDao} from "./StandupStatusDao";
 import {createZeroUtcDate} from "../utils/datefunctions";
 import {DynamoDB} from "aws-sdk";
+
 import {DataMapper, QueryIterator} from "@aws/dynamodb-data-mapper";
 import {appContext, logger} from "../utils/appContext";
 

--- a/src/secrets/AwsSecretsDataSource.ts
+++ b/src/secrets/AwsSecretsDataSource.ts
@@ -3,17 +3,15 @@ import {SlackSecret, SecretDataSource, SecretKey} from "./SecretDataSource";
 import {appContext, logger} from "../utils/appContext";
 
 export class AwsSecretsDataSource implements SecretDataSource{
-    secretsManager?: SecretsManager;
-    constructor(sm?: SecretsManager) {
+    secretsManager: SecretsManager;
+    constructor(sm: SecretsManager) {
         this.secretsManager = sm;
     }
 
     async buildSecretPromise(secretToken: SecretKey) : Promise<string> {
         logger.info("Fetching secretToken " + secretToken + " from secret named " + appContext.secretName);
-        // If there is no secrets manager defined, create a new one to avoid invalid signatures
-        const sm: SecretsManager = this.secretsManager ? this.secretsManager : new SecretsManager({});
 
-        const result = await sm.getSecretValue({SecretId: appContext.secretName});
+        const result = await this.secretsManager.getSecretValue({SecretId: appContext.secretName});
         if(result.SecretString) {
             const secret = JSON.parse(result.SecretString) as SlackSecret;
             const val = secret[secretToken as keyof SlackSecret];

--- a/src/secrets/SecretDataSource.ts
+++ b/src/secrets/SecretDataSource.ts
@@ -7,3 +7,5 @@ export interface SlackSecret {
     SLACK_STANDUP_SIGNING_SECRET: string
     SLACK_STANDUP_BOT_TOKEN: string
 }
+
+export type SecretKey = "SLACK_STANDUP_SIGNING_SECRET" | "SLACK_STANDUP_BOT_TOKEN";

--- a/src/test/scripts/create-secrets.ts
+++ b/src/test/scripts/create-secrets.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env ts-node-script
 import {
     CreateSecretCommand,
-    ListSecretsCommand, SecretsManager,
+    ListSecretsCommand,
     UpdateSecretCommand
 } from "@aws-sdk/client-secrets-manager";
 import {appContext} from "../../utils/appContext";
@@ -17,7 +17,7 @@ export async function createSecretsFromEnv() {
 
     const secretString = `{"SLACK_STANDUP_SIGNING_SECRET": "${process.env.SLACK_STANDUP_SIGNING_SECRET}" ,"SLACK_STANDUP_BOT_TOKEN": "${process.env.SLACK_STANDUP_BOT_TOKEN}"}`;
 
-    const client = appContext.secretsManager ? appContext.secretsManager : new SecretsManager({});
+    const client = appContext.secretsManager!; // If we are running this, we expect the secrets manager to be defined
 
     // See if secret exists
     const listSecrets = new ListSecretsCommand({});

--- a/src/test/scripts/create-secrets.ts
+++ b/src/test/scripts/create-secrets.ts
@@ -17,7 +17,7 @@ export async function createSecretsFromEnv() {
 
     const secretString = `{"SLACK_STANDUP_SIGNING_SECRET": "${process.env.SLACK_STANDUP_SIGNING_SECRET}" ,"SLACK_STANDUP_BOT_TOKEN": "${process.env.SLACK_STANDUP_BOT_TOKEN}"}`;
 
-    const client = appContext.secretsManager!; // If we are running this, we expect the secrets manager to be defined
+    const client = appContext.secretsManager;
 
     // See if secret exists
     const listSecrets = new ListSecretsCommand({});

--- a/src/utils/appContext.ts
+++ b/src/utils/appContext.ts
@@ -12,7 +12,7 @@ export const logger = new ConsoleLogger()
 export const appContext: Context = isLocal() ? createLocalContext() : isDev()? createDevContext() : createContext();
 
 export interface Context {
-    secretsManager? : SecretsManager;
+    secretsManager : SecretsManager;
     secretName: SecretName;
     dynamoDbClient: DynamoDB;
     tableNamePrefix: DynamoTableNamePrefix
@@ -25,6 +25,7 @@ function createContext(): Context {
     //    logger: console
     // });
     return {
+        secretsManager: new SecretsManager({}),
         secretName: "SlackStandup-secret-prod",
         dynamoDbClient: new DynamoDB({}),
         tableNamePrefix: "prod_",
@@ -37,6 +38,7 @@ function createDevContext(): Context {
         logger: console
     });
     return {
+        secretsManager: new SecretsManager({}),
         secretName: "SlackStandup-secret-dev",
         dynamoDbClient: new DynamoDB({}),
         tableNamePrefix: "dev_",

--- a/src/utils/appContext.ts
+++ b/src/utils/appContext.ts
@@ -1,7 +1,6 @@
 import * as AWS from "aws-sdk";
 import {DynamoDB} from "aws-sdk";
 import {SecretsManager} from "@aws-sdk/client-secrets-manager";
-import {AwsSecretsDataSource} from "../secrets/AwsSecretsDataSource";
 import {ConsoleLogger} from "@slack/logger";
 
 export type SecretName = "SlackStandup-secret-prod" | "SlackStandup-secret-dev";
@@ -10,7 +9,7 @@ export type DynamoTableNamePrefix = "dev_" | "prod_" | "local_";
 
 export const logger = new ConsoleLogger()
 
-export const appContext = isLocal() ? createLocalContext() : isDev()? createDevContext() : createContext();
+export const appContext: Context = isLocal() ? createLocalContext() : isDev()? createDevContext() : createContext();
 
 export interface Context {
     secretsManager? : SecretsManager;
@@ -83,31 +82,4 @@ function createLocalContext(): Context {
         tableNamePrefix: "local_",
     };
 }
-
-export async function getSecretValue(sm: SecretsManager, secretName : string) {
-    try {
-        const data = await sm.getSecretValue(({
-            SecretId: secretName
-        }));
-
-        if(data) {
-            if (data.SecretString) {
-                const secret = data.SecretString;
-                const parsedSecret = JSON.parse(secret);
-                return parsedSecret;
-            }
-            else {
-                let buff = new Buffer(data.SecretBinary!);
-                return buff.toString('ascii');
-            }
-        }
-    }
-    catch (e) {
-        logger.error('Error retrieving secrets', e);
-        throw e;
-    }
-    return undefined;
-}
-
-export const dataSource = new AwsSecretsDataSource(appContext.secretsManager!);
 export const blockId = new RegExp("change-msg-.*");


### PR DESCRIPTION
Due to lambda init, async init is stopped halfway through. Async init resumes when a request to the handler is made, but that could cause errors getting a secret; secrets request signatures have a five minute timeout, so if the first request is later than that, secret retrieval will fail.

This PR adds a 4 minute warmer to make sure the first request is always under that time limit.